### PR TITLE
Split resource data from the right

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -197,7 +197,7 @@ impl FromResource for (Namespace, Capability) {
             .strip_prefix(RESOURCE_PREFIX)
             .ok_or_else(|| Error::InvalidResourcePrefix(resource.to_string()))
             .and_then(|rest| {
-                rest.split_once(':')
+                rest.rsplit_once(':')
                     .ok_or_else(|| Error::MissingBody(resource.to_string()))
             })
             .and_then(|(namespace, data)| {


### PR DESCRIPTION
I had this resource `urn:capability:http://example.edu/credentials/1872:eyJkZWZhdWx0QWN0aW9ucyI6WyJwcmVzZW50Il19` which is probably invalid? But anyway, feels like a valid resource could have extra `:`s.