### PR TITLE
Rename to 'capgrok'.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "siwe-capability-delegation"
-version = "0.2.0"
+name = "capgrok"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,50 +1,54 @@
-# SIWE Delegation
+# Capgrok - capabilities for humans to read.
 
-Build SIWE messages with capability delegations encoded in the statement and resources.
+Use this crate to build wallet-signable messages with capability delegations. The generated message contains two representations of the capabilities: an unambiguous machine-readable representation, and a human-readable description. Of the two representations, the latter is deterministically generated from the former.
 
-Use this crate to create a delegation SIWE message, by replacing the resource list with a list of capabilities and the statement with a generated description of those capabilities.
+## Message formats
 
-## Example
+We currently support the following message formats:
+* [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In With Ethereum (SIWE)
 
-An example with default actions for the `credential` namespace, and no default actions and multiple targets with actions for the `kepler` namespace.
+## SIWE Examples
+
+An example with:
+- the capability to `present` any credential
+- the capability to `present` credentials of type `type1` (technically redundant)
+- the capability to `list`, `get` and retrieve `metadata` from the kepler location `kepler:ens:example.eth://default/kv`
+- the capability to `list`, `get`, retrieve `metadata`, `put` and `delete` from the kepler locations `kepler:ens:example.eth://default/kv/public` and `kepler:ens:example.eth://default/kv/dapp-space`
 ```rust
 let credential: Namespace = "credential".parse().unwrap();
 let kepler: Namespace = "kepler".parse().unwrap();
 
 let msg = Builder::new()
-    .with_default_actions(&credential, vec!["present".into()])
+    .with_default_actions(&credential, ["present"])
+    .with_actions(&credential, "type:type1", ["present"])
     .with_actions(
-	&kepler,
-	"kepler:ens:example.eth://default/kv".to_string(),
-	["list", "get", "metadata"].iter().map(|&s| s.into()),
+        &kepler,
+        "kepler:ens:example.eth://default/kv",
+        ["list", "get", "metadata"],
     )
     .with_actions(
-	&kepler,
-	"kepler:ens:example.eth://default/kv/public".to_string(),
-	["list", "get", "metadata", "put", "delete"]
-	    .iter()
-	    .map(|&s| s.into()),
+        &kepler,
+        "kepler:ens:example.eth://default/kv/public",
+        ["list", "get", "metadata", "put", "delete"],
     )
     .with_actions(
-	&kepler,
-	"kepler:ens:example.eth://default/kv/dapp-space".to_string(),
-	["list", "get", "metadata", "put", "delete"]
-	    .iter()
-	    .map(|&s| s.into()),
+        &kepler,
+        "kepler:ens:example.eth://default/kv/dapp-space",
+        ["list", "get", "metadata", "put", "delete"],
     )
     .build(Message {
-	domain: "example.com".parse().unwrap(),
-	address: Default::default(),
-	statement: None,
-	uri: "did:key:example".parse().unwrap(),
-	version: siwe::Version::V1,
-	chain_id: 1,
-	nonce: "mynonce1".into(),
-	issued_at: "2022-06-21T12:00:00.000Z".parse().unwrap(),
-	expiration_time: None,
-	not_before: None,
-	request_id: None,
-	resources: vec![],
+        domain: "example.com".parse().unwrap(),
+        address: Default::default(),
+        statement: None,
+        uri: "did:key:example".parse().unwrap(),
+        version: siwe::Version::V1,
+        chain_id: 1,
+        nonce: "mynonce1".into(),
+        issued_at: "2022-06-21T12:00:00.000Z".parse().unwrap(),
+        expiration_time: None,
+        not_before: None,
+        request_id: None,
+        resources: vec![],
     })?;
 ```
 
@@ -53,7 +57,7 @@ Which produces this SIWE message:
 example.com wants you to sign in with your Ethereum account:
 0x0000000000000000000000000000000000000000
 
-By signing this message I am signing in with Ethereum and authorizing the presented URI to perform the following actions on my behalf: (1) credential: present for any. (2) kepler: list, get, metadata for kepler:ens:example.eth://default/kv. (3) kepler: list, get, metadata, put, delete for kepler:ens:example.eth://default/kv/dapp-space, kepler:ens:example.eth://default/kv/public.
+By signing this message I am signing in with Ethereum and authorizing the presented URI to perform the following actions on my behalf: (1) credential: present for any. (2) credential: present for type:type1. (3) kepler: list, get, metadata for kepler:ens:example.eth://default/kv. (4) kepler: list, get, metadata, put, delete for kepler:ens:example.eth://default/kv/dapp-space, kepler:ens:example.eth://default/kv/public.
 
 URI: did:key:example
 Version: 1
@@ -61,8 +65,8 @@ Chain ID: 1
 Nonce: mynonce1
 Issued At: 2022-06-21T12:00:00.000Z
 Resources:
-- urn:capability:credential:eyJkZWZhdWx0QWN0aW9ucyI6WyJwcmVzZW50Il19
-- urn:capability:kepler:eyJ0YXJnZXRlZEFjdGlvbnMiOnsia2VwbGVyOmVuczpleGFtcGxlLmV0aDovL2RlZmF1bHQva3YiOlsibGlzdCIsImdldCIsIm1ldGFkYXRhIl0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L2RhcHAtc3BhY2UiOlsibGlzdCIsImdldCIsIm1ldGFkYXRhIiwicHV0IiwiZGVsZXRlIl0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L3B1YmxpYyI6WyJsaXN0IiwiZ2V0IiwibWV0YWRhdGEiLCJwdXQiLCJkZWxldGUiXX19
+- urn:capability:credential:eyJkZWZhdWx0QWN0aW9ucyI6WyJwcmVzZW50Il0sInRhcmdldGVkQWN0aW9ucyI6eyJ0eXBlOnR5cGUxIjpbInByZXNlbnQiXX19
+- urn:capability:kepler:eyJ0YXJnZXRlZEFjdGlvbnMiOnsia2VwbGVyOmVuczpleGFtcGxlLmV0aDovL2RlZmF1bHQva3YiOlsibGlzdCIsImdldCIsIm1ldGFkYXRhIl0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L2RhcHAtc3BhY2UiOlsibGlzdCIsImdldCIsIm1ldGFkYXRhIiwicHV0IiwiZGVsZXRlIl0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L3B1YmxpYyI6WyJsaXN0IiwiZ2V0IiwibWV0YWRhdGEiLCJwdXQiLCJkZWxldGUiXX1
 ```
 
 ### Sign-in only

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -60,17 +60,20 @@ impl Builder {
     }
 
     /// Extend the set of default actions for a namespace.
-    pub fn with_default_action(mut self, namespace: &Namespace, action: String) -> Self {
+    pub fn with_default_action<S>(mut self, namespace: &Namespace, action: S) -> Self
+    where
+        S: Into<String>,
+    {
         self.namespace(namespace).default_actions.insert(action);
         self
     }
 
     /// Extend the set of default actions for a namespace.
-    pub fn with_default_actions<I: IntoIterator<Item = String>>(
-        mut self,
-        namespace: &Namespace,
-        actions: I,
-    ) -> Self {
+    pub fn with_default_actions<I, S>(mut self, namespace: &Namespace, actions: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
         self.namespace(namespace)
             .default_actions
             .insert_all(actions);
@@ -78,7 +81,12 @@ impl Builder {
     }
 
     /// Extend the set of actions for a target in a namespace.
-    pub fn with_action(mut self, namespace: &Namespace, target: String, action: String) -> Self {
+    pub fn with_action<T, S>(mut self, namespace: &Namespace, target: T, action: S) -> Self
+    where
+        T: Into<String>,
+        S: Into<String>,
+    {
+        let target = target.into();
         if let Some(actions) = self.namespace(namespace).targeted_actions.get_mut(&target) {
             actions.insert(action);
         } else {
@@ -90,12 +98,13 @@ impl Builder {
     }
 
     /// Extend the set of actions for a target in a namespace.
-    pub fn with_actions<I: IntoIterator<Item = String>>(
-        mut self,
-        namespace: &Namespace,
-        target: String,
-        actions: I,
-    ) -> Self {
+    pub fn with_actions<I, S, T>(mut self, namespace: &Namespace, target: T, actions: I) -> Self
+    where
+        T: Into<String>,
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        let target = target.into();
         if let Some(current_actions) = self.namespace(namespace).targeted_actions.get_mut(&target) {
             current_actions.insert_all(actions);
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,25 +53,22 @@ mod test {
         let kepler: Namespace = "kepler".parse().unwrap();
 
         let msg = Builder::new()
-            .with_default_actions(&credential, vec!["present".into()])
+            .with_default_actions(&credential, ["present"])
+            .with_actions(&credential, "type:type1", ["present"])
             .with_actions(
                 &kepler,
-                "kepler:ens:example.eth://default/kv".to_string(),
-                ["list", "get", "metadata"].iter().map(|&s| s.into()),
+                "kepler:ens:example.eth://default/kv",
+                ["list", "get", "metadata"],
             )
             .with_actions(
                 &kepler,
-                "kepler:ens:example.eth://default/kv/public".to_string(),
-                ["list", "get", "metadata", "put", "delete"]
-                    .iter()
-                    .map(|&s| s.into()),
+                "kepler:ens:example.eth://default/kv/public",
+                ["list", "get", "metadata", "put", "delete"],
             )
             .with_actions(
                 &kepler,
-                "kepler:ens:example.eth://default/kv/dapp-space".to_string(),
-                ["list", "get", "metadata", "put", "delete"]
-                    .iter()
-                    .map(|&s| s.into()),
+                "kepler:ens:example.eth://default/kv/dapp-space",
+                ["list", "get", "metadata", "put", "delete"],
             )
             .build(Message {
                 domain: "example.com".parse().unwrap(),

--- a/src/set.rs
+++ b/src/set.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// should use the [`AsRef`] implementation to convert to a slice.
 pub struct Set<T: Eq>(Vec<T>);
 
-impl<T: Eq> FromIterator<T> for Set<T> {
+impl<T: Eq, S: Into<T>> FromIterator<S> for Set<T> {
     fn from_iter<I>(i: I) -> Self
     where
-        I: IntoIterator<Item = T>,
+        I: IntoIterator<Item = S>,
     {
         let iter = i.into_iter();
         let inner = Vec::with_capacity(iter.size_hint().0);
@@ -39,16 +39,21 @@ impl<T: Eq> Set<T> {
     /// Insert a new element.
     ///
     /// Returns true if inserted, false if the element already exists in the set.
-    pub fn insert(&mut self, s: T) -> bool {
-        if !self.0.contains(&s) {
-            self.0.push(s);
+    pub fn insert<S: Into<T>>(&mut self, s: S) -> bool {
+        let t = s.into();
+        if !self.0.contains(&t) {
+            self.0.push(t);
             return true;
         }
         false
     }
 
     /// Insert multiple new elements.
-    pub fn insert_all<I: IntoIterator<Item = T>>(&mut self, ts: I) {
+    pub fn insert_all<I, S>(&mut self, ts: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<T>,
+    {
         ts.into_iter().for_each(|t| {
             self.insert(t);
         })

--- a/tests/siwe_with_caps.txt
+++ b/tests/siwe_with_caps.txt
@@ -1,7 +1,7 @@
 example.com wants you to sign in with your Ethereum account:
 0x0000000000000000000000000000000000000000
 
-By signing this message I am signing in with Ethereum and authorizing the presented URI to perform the following actions on my behalf: (1) credential: present for any. (2) kepler: list, get, metadata for kepler:ens:example.eth://default/kv. (3) kepler: list, get, metadata, put, delete for kepler:ens:example.eth://default/kv/dapp-space, kepler:ens:example.eth://default/kv/public.
+By signing this message I am signing in with Ethereum and authorizing the presented URI to perform the following actions on my behalf: (1) credential: present for any. (2) credential: present for type:type1. (3) kepler: list, get, metadata for kepler:ens:example.eth://default/kv. (4) kepler: list, get, metadata, put, delete for kepler:ens:example.eth://default/kv/dapp-space, kepler:ens:example.eth://default/kv/public.
 
 URI: did:key:example
 Version: 1
@@ -9,5 +9,5 @@ Chain ID: 1
 Nonce: mynonce1
 Issued At: 2022-06-21T12:00:00.000Z
 Resources:
-- urn:capability:credential:eyJkZWZhdWx0QWN0aW9ucyI6WyJwcmVzZW50Il19
+- urn:capability:credential:eyJkZWZhdWx0QWN0aW9ucyI6WyJwcmVzZW50Il0sInRhcmdldGVkQWN0aW9ucyI6eyJ0eXBlOnR5cGUxIjpbInByZXNlbnQiXX19
 - urn:capability:kepler:eyJ0YXJnZXRlZEFjdGlvbnMiOnsia2VwbGVyOmVuczpleGFtcGxlLmV0aDovL2RlZmF1bHQva3YiOlsibGlzdCIsImdldCIsIm1ldGFkYXRhIl0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L2RhcHAtc3BhY2UiOlsibGlzdCIsImdldCIsIm1ldGFkYXRhIiwicHV0IiwiZGVsZXRlIl0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L3B1YmxpYyI6WyJsaXN0IiwiZ2V0IiwibWV0YWRhdGEiLCJwdXQiLCJkZWxldGUiXX19


### PR DESCRIPTION
Also:
* did a bit of type wrangling to improve the ergonomics further and make the examples look prettier.
* added an additional target to the example.