### PR TITLE
Use single quotes in statement

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -236,11 +236,11 @@ where
     fn to_statement_lines(&self) -> impl Iterator<Item = String> + '_ {
         self.to_line_groups().map(|(resource, namespace, names)| {
             format!(
-                "\"{}\": {} for \"{}\".",
+                "'{}': {} for '{}'.",
                 namespace,
                 names
                     .iter()
-                    .map(|an| format!("\"{an}\""))
+                    .map(|an| format!("'{an}'"))
                     .collect::<Vec<String>>()
                     .join(", "),
                 resource

--- a/tests/siwe_with_caps.txt
+++ b/tests/siwe_with_caps.txt
@@ -1,7 +1,7 @@
 example.com wants you to sign in with your Ethereum account:
 0x0000000000000000000000000000000000000000
 
-I further authorize the stated URI to perform the following actions on my behalf: (1) "kv": "get", "list", "metadata" for "kepler:ens:example.eth://default/kv". (2) "kv": "delete", "get", "list", "metadata", "put" for "kepler:ens:example.eth://default/kv/dapp-space". (3) "kv": "delete", "get", "list", "metadata", "put" for "kepler:ens:example.eth://default/kv/public". (4) "credential": "present" for "urn:credential:type:type1".
+I further authorize the stated URI to perform the following actions on my behalf: (1) 'kv': 'get', 'list', 'metadata' for 'kepler:ens:example.eth://default/kv'. (2) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/dapp-space'. (3) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/public'. (4) 'credential': 'present' for 'urn:credential:type:type1'.
 
 URI: did:key:example
 Version: 1

--- a/tests/siwe_with_interleaved_resources.txt
+++ b/tests/siwe_with_interleaved_resources.txt
@@ -1,7 +1,7 @@
 example.com wants you to sign in with your Ethereum account:
 0x0000000000000000000000000000000000000000
 
-I further authorize the stated URI to perform the following actions on my behalf: (1) "credential": "present" for "credential:*". (2) "kv": "get", "list", "metadata" for "kepler:ens:example.eth://default/".
+I further authorize the stated URI to perform the following actions on my behalf: (1) 'credential': 'present' for 'credential:*'. (2) 'kv': 'get', 'list', 'metadata' for 'kepler:ens:example.eth://default/'.
 
 URI: did:key:example
 Version: 1

--- a/tests/siwe_with_statement.txt
+++ b/tests/siwe_with_statement.txt
@@ -1,7 +1,7 @@
 example.com wants you to sign in with your Ethereum account:
 0x0000000000000000000000000000000000000000
 
-Some custom statement. I further authorize the stated URI to perform the following actions on my behalf: (1) "credential": "present" for "credential:*".
+Some custom statement. I further authorize the stated URI to perform the following actions on my behalf: (1) 'credential': 'present' for 'credential:*'.
 
 URI: did:key:example
 Version: 1


### PR DESCRIPTION
# Why

Similar to https://github.com/spruceid/recap-ts/pull/11.

tl;DR - Double quotes are not parseable per the ABNF grammar specified in [siwe-parser](https://github.com/spruceid/siwe/tree/main/packages/siwe-parser).

Currently we are generating double quote marks `"` which is not part of the grammar that is specified in the siwe-parser library (https://github.com/spruceid/siwe/blob/main/packages/siwe-parser/lib/abnf.ts#L108-L112). The result is that, when I try to pass a SIWE message (with caps declared in the statement) as a string into `new SiweMessage()`, the parser is used and it throws an error saying the SIWE message doesn't conform to the ABNF / specified grammar. I've confirmed this with a new test case with an added `"` in the parsing_positive.json in the  siwe package, as an MCVE.

# What

Statements with capabilities are produced with `'` single quote marks instead of `"` double quote marks in order to be correctly parsed.

# Testing

`cargo build`

`cargo test`
